### PR TITLE
included train/val split

### DIFF
--- a/backend/notebooks/SignFlow.ipynb
+++ b/backend/notebooks/SignFlow.ipynb
@@ -746,7 +746,8 @@
     "if y_cat.shape == (input_length, n_classes):\n",
     "    print(f'✅ y has been initialized with Shape {y_cat.shape}!')\n",
     "else:\n",
-    "    print('❌ y has not been initialized properly!')\n"
+    "    print('❌ y has not been initialized properly!')\n",
+    "print()\n"
    ]
   },
   {
@@ -967,7 +968,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# 7) Testing output and generating videos #"
+    "# 8) Testing output and generating videos #"
    ]
   },
   {


### PR DESCRIPTION
Fixed an issue where augmenting all videos, including the validation set, lead to very low accuracy score of the CNN model by splitting the data set into train and validation sets before augmentation, rather than after.